### PR TITLE
feat: Add legacy GitHub secrets for backward compatibility with older nf-core tools

### DIFF
--- a/pulumi/AWSMegatests/__main__.py
+++ b/pulumi/AWSMegatests/__main__.py
@@ -257,6 +257,37 @@ workspace_id_variable = github.ActionsOrganizationVariable(
     opts=pulumi.ResourceOptions(provider=github_provider),
 )
 
+# Legacy compatibility for older nf-core tools templates
+# See: https://github.com/nf-core/ops/issues/162
+# These duplicate the new variable names into the old secret names expected by nf-core tools v3.3.2 and earlier
+
+# Legacy: TOWER_WORKSPACE_ID as secret (duplicates the variable above)
+legacy_workspace_id_secret = github.ActionsOrganizationSecret(
+    "legacy-tower-workspace-id",
+    visibility="all",
+    secret_name="TOWER_WORKSPACE_ID",
+    plaintext_value=tower_workspace_id,
+    opts=pulumi.ResourceOptions(provider=github_provider),
+)
+
+# Legacy: TOWER_COMPUTE_ENV as secret (points to CPU environment)
+legacy_compute_env_secret = github.ActionsOrganizationSecret(
+    "legacy-tower-compute-env",
+    visibility="all",
+    secret_name="TOWER_COMPUTE_ENV",
+    plaintext_value=cpu_compute_env_id,
+    opts=pulumi.ResourceOptions(provider=github_provider),
+)
+
+# Legacy: AWS_S3_BUCKET as variable
+legacy_s3_bucket_variable = github.ActionsOrganizationVariable(
+    "legacy-aws-s3-bucket",
+    visibility="all",
+    variable_name="AWS_S3_BUCKET",
+    value="nf-core-awsmegatests",
+    opts=pulumi.ResourceOptions(provider=github_provider),
+)
+
 # Export the created GitHub resources
 pulumi.export(
     "github_resources",
@@ -266,9 +297,12 @@ pulumi.export(
             "compute_env_gpu": gpu_variable.variable_name,
             "compute_env_arm": arm_variable.variable_name,
             "tower_workspace_id": workspace_id_variable.variable_name,
+            "legacy_aws_s3_bucket": legacy_s3_bucket_variable.variable_name,
         },
         "secrets": {
             "tower_access_token": seqera_token_secret.secret_name,
+            "legacy_tower_workspace_id": legacy_workspace_id_secret.secret_name,
+            "legacy_tower_compute_env": legacy_compute_env_secret.secret_name,
         },
     },
 )


### PR DESCRIPTION
Add duplicate GitHub secrets/variables using legacy naming conventions:
- TOWER_WORKSPACE_ID (secret) - duplicates workspace variable
- TOWER_COMPUTE_ENV (secret) - points to CPU compute environment
- AWS_S3_BUCKET (variable) - hardcoded bucket name

These provide compatibility with nf-core tools v3.3.2 and earlier that expect
the old secret naming format, addressing secret masking issues.

Resolves: https://github.com/nf-core/ops/issues/162

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
