### PR TITLE
fix wrong field name

### DIFF
--- a/.github/renovate/default.json5
+++ b/.github/renovate/default.json5
@@ -57,7 +57,7 @@
   customManagers: [
     {
       customType: "regex",
-      matchFileNames: ["**/.pre-commit*config*.yaml"],
+      managerFilePatterns: ["**/.pre-commit*config*.yaml"],
       matchStrings: ["- (?<depName>[^@\\s]+)@(?<currentValue>[^\\s#]+)"],
       datasourceTemplate: "npm",
       versioningTemplate: "npm",


### PR DESCRIPTION
`matchFileNames` field is only valid inside `packageRules`. `customManagers` require `managerFilePatterns`